### PR TITLE
Fix the order of operations in the parser.

### DIFF
--- a/crates/til_parser/src/generic_param.rs
+++ b/crates/til_parser/src/generic_param.rs
@@ -163,7 +163,7 @@ pub fn generic_parameter_assignment(
 
         let product = atom
             .clone()
-            .then(op.then(param_assignment).repeated())
+            .then(op.then(atom).repeated())
             .foldl(parse_math_combination);
 
         // Sum and subtraction have the same precedence (but a lower precedence than products)

--- a/crates/til_vhdl/tests/til_files/simple_generics.til
+++ b/crates/til_vhdl/tests/til_files/simple_generics.til
@@ -16,13 +16,11 @@ namespace generics::space {
     type stream_assigned2 = genericstream<4 % 10>;
     type stream_assigned3 = genericstream<4 * 2>;
     type stream_assigned4 = genericstream<6 - 2>;
-    // No quick solution for folding precedence after the fact, unfortunately
-    // So for the time being, we'll ignore this
-    // type stream_assigned5 = genericstream<6 - 2 * 3 + 4 / 2 - 1 + 2>;
-    // type stream_assigned6 = genericstream<d = 6 - 2 * 3 + 4 / 2 - 1 + 2>;
-    // type stream_assigned7 = genericstream<d = 6 - 2 * 3 + 4 / 2 - 1 + 2,>;
-    // type stream_assigned8 = genericstream<6 - 2 * 3 + 4 / 2 - 1 + 2,>;
-    // type stream_assigned9 = genericstream<(6 - 2) * 3 + 4 / 2 - (1 + 2),>;
+    type stream_assigned5 = genericstream<6 - 2 * 3 + 4 / 2 - 1 + 2>;
+    type stream_assigned6 = genericstream<d = 6 - 2 * 3 + 4 / 2 - 1 + 2>;
+    type stream_assigned7 = genericstream<d = 6 - 2 * 3 + 4 / 2 - 1 + 2,>;
+    type stream_assigned8 = genericstream<6 - 2 * 3 + 4 / 2 - 1 + 2,>;
+    type stream_assigned9 = genericstream<(6 - 2) * 3 + 4 / 2 - (1 + 2),>;
     
     type stream_reassigned1<d: dimensionality = 4> = genericstream<d>;
     type stream_reassigned2<d: dimensionality = 4> = genericstream<d,>;


### PR DESCRIPTION
Yeah, I just overlooked this mistake.

Closes #127 